### PR TITLE
Add script to compile Verilog files with Verilator

### DIFF
--- a/compile_verilog.sh
+++ b/compile_verilog.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <verilog file or directory> [verilator options...]" >&2
+  exit 1
+fi
+
+if ! command -v verilator >/dev/null 2>&1; then
+  echo "Error: verilator is not installed or not in PATH." >&2
+  exit 1
+fi
+
+target=$1
+shift
+
+if [ -d "$target" ]; then
+  dir="$target"
+else
+  dir=$(dirname "$target")
+fi
+
+files=("$dir"/*.v)
+
+echo "Compiling using Verilator: ${files[*]}"
+verilator --cc "${files[@]}" -Wno-DECLFILENAME -Wno-PINNOCONNECT -Wno-fatal "$@"


### PR DESCRIPTION
## Summary
- add `compile_verilog.sh` to compile Verilog sources in a directory using Verilator

## Testing
- `./compile_verilog.sh hdl_cores/des3/des3.v`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc65f3788328bd7859136e9bcc27